### PR TITLE
`config.autoload_lib` is part of Rails 7.1

### DIFF
--- a/_posts/2023-05-02-whatever-you-do-don-t-autoload-rails-lib.md
+++ b/_posts/2023-05-02-whatever-you-do-don-t-autoload-rails-lib.md
@@ -5,7 +5,7 @@ published: true
 tags: []
 ---
 
-_**Update:** Rails v7.2 will introduce a new configuration method [`config.autoload_lib`](https://github.com/rails/rails/pull/48572) to make it safer and easier to autoload the `/lib` directory and explicitly exclude directories from autoloading. When released, this advice may no longer be relevant, though I imagine it will still be possible for developers to twist themselves into knots and cause outages with autoloading overrides._  
+_**Update:** Rails v7.1 will introduce a new configuration method [`config.autoload_lib`](https://github.com/rails/rails/pull/48572) to make it safer and easier to autoload the `/lib` directory and explicitly exclude directories from autoloading. When released, this advice may no longer be relevant, though I imagine it will still be possible for developers to twist themselves into knots and cause outages with autoloading overrides._  
 
 One of the most common problems I encounter consulting on Rails projects is that developers have previously added `lib/` to autoload paths and then twisted themselves into knots creating error-prone, project-specific conventions for subsequently un-autoloading a subset of files also in `lib/`. 
 


### PR DESCRIPTION
Great post!

I am using Rails 7.1 beta and can confirm that the new `autoload_lib` feature will in fact be part of Rails 7.1, not 7.2.

https://edgeguides.rubyonrails.org/7_1_release_notes.html#introducing-config-autoload-lib-and-config-autoload-lib-once-for-enhanced-autoloading